### PR TITLE
Remove inisiatif/contract dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "inisiatif/contract": "^1.1",
         "ramsey/uuid": "^4.0"
     },
     "require-dev": {

--- a/database/migrations/create_branch_tables.php
+++ b/database/migrations/create_branch_tables.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-return new class() extends Migration
+return new class extends Migration
 {
     public function up(): void
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,88 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.0@a0a9c27630bcf8301ee78cb06741d2907d8c9fef">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="src/Abstracts/Event.php">
     <UnusedClass>
-      <code>Event</code>
+      <code><![CDATA[Event]]></code>
     </UnusedClass>
   </file>
   <file src="src/Abstracts/ModelBuilder.php">
     <UnusedClass>
-      <code>ModelBuilder</code>
+      <code><![CDATA[ModelBuilder]]></code>
     </UnusedClass>
   </file>
   <file src="src/Common.php">
     <PossiblyUnusedMethod>
-      <code>ignoreMigrations</code>
-      <code>runningMigrations</code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="src/Concerns/EloquentAwareRepository.php">
-    <PossiblyUnusedMethod>
-      <code>newModelQuery</code>
+      <code><![CDATA[ignoreMigrations]]></code>
+      <code><![CDATA[runningMigrations]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Concerns/TaggableCacheAware.php">
-    <PossiblyUnusedMethod>
-      <code>disableCache</code>
-      <code>makeForeverCache</code>
-    </PossiblyUnusedMethod>
     <PossiblyUnusedReturnValue>
-      <code>bool</code>
+      <code><![CDATA[bool]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="src/Concerns/UuidPrimaryKey.php">
     <PossiblyUnusedMethod>
-      <code>bootUuidPrimaryKey</code>
-      <code>getId</code>
-      <code>setId</code>
+      <code><![CDATA[bootUuidPrimaryKey]]></code>
+      <code><![CDATA[getId]]></code>
+      <code><![CDATA[setId]]></code>
+    </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Contracts/EloquentAwareRepositoryInterface.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[beginTransaction]]></code>
+      <code><![CDATA[commit]]></code>
+      <code><![CDATA[newModelQuery]]></code>
+      <code><![CDATA[rollBack]]></code>
+      <code><![CDATA[transaction]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Contracts/HasBranchInterface.php">
     <UnusedClass>
-      <code>HasBranchInterface</code>
+      <code><![CDATA[HasBranchInterface]]></code>
     </UnusedClass>
+  </file>
+  <file src="src/Contracts/ModelRepositoryInterface.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[delete]]></code>
+      <code><![CDATA[findOneUsingColumns]]></code>
+      <code><![CDATA[findUsingColumn]]></code>
+      <code><![CDATA[findUsingColumns]]></code>
+      <code><![CDATA[save]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Contracts/Notable.php">
     <UnusedClass>
-      <code>Notable</code>
+      <code><![CDATA[Notable]]></code>
     </UnusedClass>
+  </file>
+  <file src="src/Contracts/TaggableCacheAwareInterface.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[disableCache]]></code>
+      <code><![CDATA[makeForeverCache]]></code>
+      <code><![CDATA[setCache]]></code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Exceptions/DomainActionException.php">
     <UnusedClass>
-      <code>DomainActionException</code>
+      <code><![CDATA[DomainActionException]]></code>
     </UnusedClass>
   </file>
   <file src="src/Exceptions/DomainModelExistException.php">
     <UnusedClass>
-      <code>DomainModelExistException</code>
+      <code><![CDATA[DomainModelExistException]]></code>
     </UnusedClass>
   </file>
   <file src="src/Exceptions/DomainModelNotExistException.php">
     <UnusedClass>
-      <code>DomainModelNotExistException</code>
+      <code><![CDATA[DomainModelNotExistException]]></code>
     </UnusedClass>
   </file>
   <file src="src/Factories/BranchFactory.php">
-    <MissingTemplateParam>
-      <code>BranchFactory</code>
-    </MissingTemplateParam>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->faker]]></code>
       <code><![CDATA[$this->faker]]></code>
       <code><![CDATA[$this->faker->uuid]]></code>
     </UndefinedDocblockClass>
     <UnusedClass>
-      <code>BranchFactory</code>
+      <code><![CDATA[BranchFactory]]></code>
     </UnusedClass>
   </file>
   <file src="src/Providers/CommonServiceProvider.php">
     <UnusedClass>
-      <code>CommonServiceProvider</code>
+      <code><![CDATA[CommonServiceProvider]]></code>
     </UnusedClass>
   </file>
   <file src="src/Providers/TelescopeServiceProvider.php">
     <UnusedClass>
-      <code>TelescopeServiceProvider</code>
+      <code><![CDATA[TelescopeServiceProvider]]></code>
     </UnusedClass>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -79,6 +79,9 @@
     </UnusedClass>
   </file>
   <file src="src/Factories/BranchFactory.php">
+    <MissingTemplateParam>
+      <code><![CDATA[BranchFactory]]></code>
+    </MissingTemplateParam>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->faker]]></code>
       <code><![CDATA[$this->faker]]></code>

--- a/src/Abstracts/AbstractRepository.php
+++ b/src/Abstracts/AbstractRepository.php
@@ -10,11 +10,11 @@ use Ramsey\Uuid\UuidInterface;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Inisiatif\Package\Common\Concerns\TaggableCacheAware;
+use Inisiatif\Package\Common\Contracts\ResourceInterface;
 use Inisiatif\Package\Common\Concerns\EloquentAwareRepository;
-use Inisiatif\Package\Contract\Common\Model\ResourceInterface;
-use Inisiatif\Package\Contract\Common\Concern\TaggableCacheAwareInterface;
-use Inisiatif\Package\Contract\Common\Repository\ModelRepositoryInterface;
-use Inisiatif\Package\Contract\Common\Repository\EloquentAwareRepositoryInterface;
+use Inisiatif\Package\Common\Contracts\ModelRepositoryInterface;
+use Inisiatif\Package\Common\Contracts\TaggableCacheAwareInterface;
+use Inisiatif\Package\Common\Contracts\EloquentAwareRepositoryInterface;
 
 abstract class AbstractRepository implements EloquentAwareRepositoryInterface, ModelRepositoryInterface, TaggableCacheAwareInterface
 {

--- a/src/Concerns/EloquentAwareRepository.php
+++ b/src/Concerns/EloquentAwareRepository.php
@@ -12,7 +12,7 @@ use RuntimeException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\ConnectionInterface;
-use Inisiatif\Package\Contract\Common\Model\ResourceInterface;
+use Inisiatif\Package\Common\Contracts\ResourceInterface;
 
 trait EloquentAwareRepository
 {

--- a/src/Contracts/EloquentAwareRepositoryInterface.php
+++ b/src/Contracts/EloquentAwareRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inisiatif\Package\Common\Contracts;
+
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\ConnectionInterface;
+
+interface EloquentAwareRepositoryInterface
+{
+    public function getModel(): Model;
+
+    public function newModelQuery(): Builder;
+
+    public function getConnection(): ConnectionInterface;
+
+    /**
+     * @psalm-return mixed
+     */
+    public function transaction(Closure $callback, int $attempts = 1);
+
+    public function beginTransaction(): void;
+
+    public function commit(): void;
+
+    public function rollBack(): void;
+}

--- a/src/Contracts/ModelRepositoryInterface.php
+++ b/src/Contracts/ModelRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inisiatif\Package\Common\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface ModelRepositoryInterface
+{
+    public function save(ResourceInterface $resource): bool;
+
+    public function delete($id): void;
+
+    public function findUsingId($id);
+
+    public function findOneUsingColumn(string $column, $value);
+
+    public function findOneUsingColumns(array $columns);
+
+    public function findUsingColumn(string $column, $value): Collection;
+
+    public function findUsingColumns(array $columns);
+}

--- a/src/Contracts/ResourceInterface.php
+++ b/src/Contracts/ResourceInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inisiatif\Package\Common\Contracts;
+
+/**
+ * Marker interface for model/resource.
+ */
+interface ResourceInterface {}

--- a/src/Contracts/TaggableCacheAwareInterface.php
+++ b/src/Contracts/TaggableCacheAwareInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inisiatif\Package\Common\Contracts;
+
+use Illuminate\Contracts\Cache\Factory;
+use Illuminate\Contracts\Cache\Repository;
+
+interface TaggableCacheAwareInterface
+{
+    public function getTagName(): string;
+
+    public function getCache(): Repository;
+
+    public function setCache(Factory $factory): self;
+
+    public function disableCache(): void;
+
+    public function makeForeverCache(): void;
+
+    public function changeCacheLifetime(int $cacheLifetime): void;
+}

--- a/src/Exceptions/DomainActionException.php
+++ b/src/Exceptions/DomainActionException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Inisiatif\Package\Common\Exceptions;
 
-final class DomainActionException extends DomainException
-{
-}
+final class DomainActionException extends DomainException {}

--- a/src/Exceptions/DomainException.php
+++ b/src/Exceptions/DomainException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Inisiatif\Package\Common\Exceptions;
 
-abstract class DomainException extends \Exception
-{
-}
+abstract class DomainException extends \Exception {}

--- a/src/Exceptions/DomainModelExistException.php
+++ b/src/Exceptions/DomainModelExistException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Inisiatif\Package\Common\Exceptions;
 
-final class DomainModelExistException extends DomainException
-{
-}
+final class DomainModelExistException extends DomainException {}

--- a/src/Exceptions/DomainModelNotExistException.php
+++ b/src/Exceptions/DomainModelNotExistException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace Inisiatif\Package\Common\Exceptions;
 
-final class DomainModelNotExistException extends DomainException
-{
-}
+final class DomainModelNotExistException extends DomainException {}


### PR DESCRIPTION
## Summary
- Menghapus dependency `inisiatif/contract` package
- Membuat interface lokal sebagai pengganti di `src/Contracts/`:
  - `ResourceInterface` - marker interface untuk model/resource
  - `TaggableCacheAwareInterface` - interface untuk cache-aware repositories
  - `ModelRepositoryInterface` - interface untuk operasi repository model
  - `EloquentAwareRepositoryInterface` - interface untuk operasi repository Eloquent
- Update import statements di `AbstractRepository` dan `EloquentAwareRepository`

## Test plan
- [x] `composer update` - package berhasil dihapus
- [x] `composer analyse` - tidak ada error Psalm
- [x] `composer format` - code style konsisten

🤖 Generated with [Claude Code](https://claude.ai/code)